### PR TITLE
fix README's

### DIFF
--- a/riot-basics/gpio/README.md
+++ b/riot-basics/gpio/README.md
@@ -14,7 +14,18 @@ used to toggle an on-board LED.
 
 **Note:** Use predefined `BTN_B1_PIN` and `LED1_PIN` macros and include `board.h`
 
-**Objective:**
+- Add the GPIO's feature to the requirements of the application (in the `Makefile`):
+
+```mk
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+```
+
+- Add the GPIO header file in your application:
+
+```c
+#include "periph/gpio.h"
+```
 
 - Write an application with one thread that waits for incoming messages
 
@@ -29,6 +40,10 @@ used to toggle an on-board LED.
   thread &#x21d2; it toggles the LED0 state
 
 _Note: we won't take care of the debounce issue_
+
+_Note: don't connect the X-NUCLEO-IKS01A2 extension board since the on-board
+       button pin is connected to the X-NUCLEO-IKS01A2 level translator which
+       affects the level state for the button._
 
 Now let's continue in the
 [riot-basics slides](https://aabadie.github.io/riot-course/slides/03-riot-basics/#28).

--- a/riot-basics/rtc/README.md
+++ b/riot-basics/rtc/README.md
@@ -9,7 +9,8 @@ In this exercise, we propose to experiment the RTC API.
 1. Go to `~/riot-course-exercises/riot-basics/rtc`
 
 2. Write an application that gets the current RTC time and print it to stdout
-   (Don't forget to the `periph_rtc` to the list of required features).
+   (Don't forget to add `periph_rtc` to the list of required features and to
+   include it in your application).
 
 3. Start one thread, called `blink_thread`, that waits for incoming messages.
    For each message, the thread turns on the LED1 during 1 seconds, then it

--- a/riot-basics/thread-concurrency/README.md
+++ b/riot-basics/thread-concurrency/README.md
@@ -25,11 +25,12 @@ the exercise, you will run this same application, unchanged, on real hardware.
   to add the 200ms delay. `US_PER_MS` macro is also useful for converting ms in
   us.
 
-- Implement the logic of the writer thread: every 100ms it will modify the
-  content of the buffer. Here we want to simmulate an action that takes time,
+- Implement the logic of the writer thread: it will modify the content of the
+  buffer and the wait 100ms before doing so again. Here we want to simulate an
+  action that takes time,
   so this should be done in 3 steps:
   - Write some content in the buffer (use `sprintf` or equivalent)
-  - Wait 500ms
+  - Wait 200ms
   - Write the end of the content in the buffer
   ```c
   size_t p = sprintf(data.buffer, "start: %"PRIu32"", xtimer_now().ticks32);

--- a/riot-basics/thread-concurrency/main.c
+++ b/riot-basics/thread-concurrency/main.c
@@ -28,7 +28,7 @@ static void *thread_writer_handler(void *arg)
 {
     (void) arg;
 
-    /* Update content of buffer every 100ms, the content update takes 500ms */
+    /* Update content of buffer every 100ms, the content update takes 200ms */
 
     return NULL;
 }

--- a/riot-basics/uart/README.md
+++ b/riot-basics/uart/README.md
@@ -18,6 +18,11 @@ threads to print all characters received on the stdio.
 FEATURES_REQUIRED += periph_uart
 ```
 
+- Add the UART header file in your application:
+```c
+#include "periph/uart.h"
+```
+
 - Write an application with one thread, called `printer_thread`, that waits
   for incoming messages
 

--- a/riot-networking/gcoap/README.md
+++ b/riot-networking/gcoap/README.md
@@ -37,7 +37,11 @@ package clients.
       NULL
   };
   ```
-5. Implement the riot board GET handler:
+5. Register the coap listener:
+  ```c
+  gcoap_register_listener(&_listener);
+  ```
+6. Implement the riot board GET handler:
   - Initialize the request response:
   ```c
   gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
@@ -57,9 +61,9 @@ package clients.
       return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
   }
   ```
-6. Implement the riot cpu GET handler on the same principle as the riot board:
+7. Implement the riot cpu GET handler on the same principle as the riot board:
   use `RIOT_CPU` macro instead of `RIOT_BOARD`.
-7. Implement the `/value` GET, PUT/POST handler:
+8. Implement the `/value` GET, PUT/POST handler:
   - Read coap method flag in the packet:
   ```c
    unsigned method_flag = coap_method2flag(coap_get_code_detail(pdu));
@@ -85,7 +89,8 @@ package clients.
   else {
       return gcoap_response(pdu, buf, len, COAP_CODE_BAD_REQUEST);
   }
-8. Build and start the coap server application on `tap0`. Note the link-local
+  ```
+9. Build and start the coap server application on `tap0`. Note the link-local
   address of the server application:
   ```sh
   $ make -C ~/riot-course/exercises/riot-networking/gcoap
@@ -100,7 +105,7 @@ package clients.
   ```
   Here the link-local address of the CoAP server is **fe80::f09d:f4ff:fe58:14d4**.
   Keep the terminal open and the server application running.
-9. From the VM (or your computer), use `aiocoap-client` to send requests to the
+10. From the VM (or your computer), use `aiocoap-client` to send requests to the
   CoAP server (note the `%tapbr0` added at the end of the server link-local
   address):
   - Get the `/riot/board` and `/riot/cpu` resources:

--- a/riot-networking/sock-udp/README.md
+++ b/riot-networking/sock-udp/README.md
@@ -89,17 +89,21 @@ Both applications will run as RIOT native instances.
         return 1;
     }
     ```
+  - Implement sending CLIENT_MESSAGE to the server:
+    ```c
+    if (sock_udp_send(&sock, CLIENT_MESSAGE, sizeof(CLIENT_MESSAGE), &remote) < 0) {
+        puts("Error sending message");
+        sock_udp_close(&sock);
+        return 1;
+    }
+    ```
   - Implement the listening of the echo sent by the server:
     ```c
-    sock_udp_ep_t remote;
     ssize_t res;
     if ((res = sock_udp_recv(&sock, buf, sizeof(buf), SOCK_NO_TIMEOUT,
                              &remote)) >= 0) {
 
         printf("Message received: %s\n", (char*)buf);
-        if (sock_udp_send(&sock, buf, res, &remote) < 0) {
-            puts("Error sending reply");
-        }
     }
     ```
 

--- a/riot-networking/sock-udp/client/main.c
+++ b/riot-networking/sock-udp/client/main.c
@@ -13,7 +13,7 @@ int main(void)
 {
     /* Create the local sock UDP endpoint */
 
-    /* declate the remote sock UDP endpoint and assign the IPv6 address
+    /* declare the remote sock UDP endpoint and assign the IPv6 address
        (link-local), based on SERVER_ADDR
        TIP: use ipv6_addr_from_str function to convert to an ipv6_addr_t
        */


### PR DESCRIPTION
This PR fixes some README typos and missing instructions.

Only one example solution has been improved  (riot-basics/rtc)